### PR TITLE
Bug#69: Registration email styling

### DIFF
--- a/src/AppBundle/Action/Project/Person/ProjectPersonViewDecorator.php
+++ b/src/AppBundle/Action/Project/Person/ProjectPersonViewDecorator.php
@@ -50,10 +50,18 @@ class ProjectPersonViewDecorator
     private $warningClass = 'bg-warning';
     private $successClass = 'bg-success';
 
+    //public $infoStyle    = 'background-color: #d9edf7';
+    public $dangerStyle  = 'background-color: #f2dede';
+    public $warningStyle = 'background-color: #fcf8e3';
+    public $successStyle = 'background-color: #dff0d8';
     // Don't really like having to use methods here
     public function getRegYearClass($regYearProject)
     {
         return $this->regYear >= $regYearProject ? $this->successClass : $this->dangerClass;
+    }
+    public function getRegYearStyle($regYearProject)
+    {
+        return $this->regYear >= $regYearProject ? $this->successStyle : $this->dangerStyle;
     }
     public function getRegYear($regYearProject)
     {
@@ -64,12 +72,24 @@ class ProjectPersonViewDecorator
         $sar = $this->orgKey;
         return ($sar && substr($sar,0,1) !== 'A') ? $this->successClass : $this->dangerClass;
     }
+    public function getOrgKeyStyle()
+    {
+        $sar = $this->orgKey;
+        return ($sar && substr($sar,0,1) !== 'A') ? $this->successStyle : $this->dangerStyle;
+    }
     public function getCertClass($certKey)
     {
         if (!$this->person->hasCert($certKey)) {
             return null;
         };
         return $this->person->getCert($certKey)->verified ? $this->successClass : $this->dangerClass;
+    }
+    public function getCertStyle($certKey)
+    {
+        if (!$this->person->hasCert($certKey)) {
+            return null;
+        };
+        return $this->person->getCert($certKey)->verified ? $this->successStyle : $this->dangerStyle;
     }
     public function getCertBadge($certKey)
     {
@@ -93,7 +113,14 @@ class ProjectPersonViewDecorator
         } 
         return $role->verified ? $this->warningClass : $this->dangerClass;
     }
-public function __get($name)
+    public function getRoleStyle($role)
+    {
+        if ($role->approved) {
+            return $this->successClass;
+        } 
+        return $role->verified ? $this->warningStyle : $this->dangerStyle;
+    }
+    public function __get($name)
     {
         $person = $this->person;
         

--- a/src/AppBundle/Action/Project/Person/Register/RegisterTemplateEmail.php
+++ b/src/AppBundle/Action/Project/Person/Register/RegisterTemplateEmail.php
@@ -45,6 +45,11 @@ class RegisterTemplateEmail extends AbstractView2
         font-size: 14px;
         font-weight: bold;
     ';
+    protected $styleTd = '
+        height: 2em;
+        text-align: center;
+        vertical-align: middle;
+    ';
 
     public function __construct(
         ProjectPersonViewDecorator $projectPersonViewDecorator
@@ -149,7 +154,7 @@ EOD;
     <td style="{$personView->getCertStyle('CERT_CONCUSSION')}">{$personView->getCertBadge('CERT_CONCUSSION')}</td>
   </tr>
   <tr><td>User Notes</td><td>{$notes}</td></tr>
-  <tr><td colspan="2"><a href="{$href}">Update Tournament Plans or Availability</a></td></tr>
+  <tr><td style="{$this->styleTd}" colspan="2" ><a href="{$href}">Update Tournament Plans or Availability</a></td></tr>
 </table>
 <br>
   <p style="{$this->stylePStrong}">

--- a/src/AppBundle/Action/Project/Person/Register/RegisterTemplateEmail.php
+++ b/src/AppBundle/Action/Project/Person/Register/RegisterTemplateEmail.php
@@ -163,8 +163,7 @@ EOD;
     When it's done, your records will be updated and you'll be ready to join us at the National Games.
 </p>
 <p style="{$this->styleP}">
-    Please notify the referee administrator if your eAYSO information does not match the above information.
-    I will update zAYSO accordingly.
+    Please notify me if your eAYSO information does not match the above information and I will update zAYSO accordingly.
 </p>
 EOD;
     }

--- a/src/AppBundle/Action/Project/Person/Register/RegisterTemplateEmail.php
+++ b/src/AppBundle/Action/Project/Person/Register/RegisterTemplateEmail.php
@@ -10,6 +10,37 @@ class RegisterTemplateEmail extends AbstractView2
 {
     private $projectPersonViewDecorator;
 
+    /* define inline styling for gmail */
+    protected $styleSkHeader = '
+        position: relative;
+    ';
+    protected $styleSkFontEmail = '
+        font-size: 14px;
+    ';
+    protected $tableClass = '
+        border-spacing: 0;
+        border-collapse: collapse;
+        background-color: transparent;
+        font-size: inherit;
+        table-layout: fixed;
+        margin-left: auto;
+        margin-right: auto;
+        width: 400px;
+        border: 2px solid black;
+        margin-bottom: 0px;
+    ';
+    protected $styleBodyEmail = 'width: inherit;';
+    protected $stylePEmail = '
+        font-size: 12px;
+        text-align: center;
+    ';
+    protected $styleP = '
+        margin-bottom: 0.5em;
+    ';
+    protected $styleClearBoth = '
+        clear: both
+    ';
+
     public function __construct(
         ProjectPersonViewDecorator $projectPersonViewDecorator
     )
@@ -28,26 +59,24 @@ class RegisterTemplateEmail extends AbstractView2
 <html>
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=us-ascii">
-  <link rel="stylesheet" type="text/css" href="http://ng2016register.zayso.org/css/zayso.css" media="all">
-  <title></title>
 </head>
-<body class="email" >
+<body style="{$this->styleBodyEmail}" >
   <center>
-    <div class="skHeader">
+    <div style="{$this->styleSkHeader}">
       <h1>
           <img src="http://ng2016register.zayso.org/images/header-ipad_01.png" width="70%">
       </h1>
     </div>
     <br>
-    <p class="skFont email">AYSO WELCOMES YOU TO PALM BEACH COUNTY, FLORIDA, JULY 5-10, 2016</p>
-    <div class="clear-both"></div>
+    <p style="{$this->styleSkFontEmail}">AYSO WELCOMES YOU TO PALM BEACH COUNTY, FLORIDA, JULY 5-10, 2016</p>
+    <div style="{$this->styleClearBoth}"></div>
   </center>
   <hr>
-  <p class="email">Thank you for registering to volunteer at the 2016 National Games!</p>
+  <p style="{$this->stylePEmail}">Thank you for registering to volunteer at the 2016 National Games!</p>
   <br>
   {$this->renderHtmlPerson($personView)}
-  <br>
-  <p>
+
+  <p style="{$this->styleP}">
     As you might expect, we have a full calendar of soccer and related activities starting Tuesday, July 5 and 
     running through Sunday, July 10. 
     On Tuesday, July 5, 2016, we will have a mandatory meeting for Coaches and Referees at the 
@@ -57,18 +86,17 @@ class RegisterTemplateEmail extends AbstractView2
     A full calendar may be viewed at <a href="http://aysonationalgames.org/schedule-of-events/" target="_blank">National Games Calendar</a>.
     General information about the Games can be found at <a href="http://www.aysonationalgames.org/" target="_blank">National Games</a>.
     </p>
-    <br>
-    <p>
+    <p style="{$this->styleP}">
       I will provide additional updates in the coming weeks. 
       Please drop me a note if you have any questions about officiating at the Games or with suggestions you have on how we can 
       better communicate the information you need.
     </p>
-    <br>
-    <p>I look forward to meeting you at the Games.</p>
-    <br>
-    <p>Sincerely,</p>
+
+    <p style="{$this->styleP}">I look forward to meeting you at the Games.</p>
+
+    <p style="{$this->styleP}">Sincerely,</p>
     
-    <p>Tom Bobadilla<br>
+    <p style="{$this->styleP}">Tom Bobadilla<br>
       National Referee Administrator<br>
       2016 National Games Referee Administrator<br>
       <a href="mailto:ThomasBobadilla@ayso.org?subject=Question%20about%20the%202016%20National%Games">ThomasBobadilla@ayso.org</a>
@@ -84,9 +112,9 @@ EOD;
         $href = $this->generateUrlAbsoluteUrl('app_welcome');
         
         $notes = nl2br($this->escape($personView->notesUser));
-
+        
         return <<<EOD
-<table class="tableClass">
+<table style="{$this->tableClass}">
   <tr><td>Name          </td><td>{$this->escape($personView->name)} </td></tr>
   <tr><td>Email         </td><td>{$this->escape($personView->email)}</td></tr>
   <tr><td>Phone         </td><td>{$personView->phone}</td></tr>
@@ -98,29 +126,45 @@ EOD;
     <td>{$personView->fedId}</td>
   </tr><tr>
     <td>Section/Area/Region</td>
-    <td class="{$personView->getOrgKeyClass()}">{$personView->orgKey}</td>
+    <td style="{$personView->getOrgKeyStyle()}">{$personView->orgKey}</td>
   </tr><tr>
     <td>Membership Year</td>
-    <td class="{$personView->getRegYearClass($regYearProject)}">{$personView->getRegYear($regYearProject)}</td>
+    <td style="{$personView->getRegYearStyle($regYearProject)}">{$personView->getRegYear($regYearProject)}</td>
   </tr><tr>
     <td>Safe Haven</td>
-    <td class="{$personView->getCertClass('CERT_SAFE_HAVEN')}">{$personView->getCertBadge('CERT_SAFE_HAVEN')}</td>
+    <td style="{$personView->getCertStyle('CERT_SAFE_HAVEN')}">{$personView->getCertBadge('CERT_SAFE_HAVEN')}</td>
   </tr><tr>
     <td>Referee Badge</td>
-    <td class="{$personView->getCertClass('CERT_REFEREE')}">{$personView->getCertBadge('CERT_REFEREE')}</td>
+    <td style="{$personView->getCertStyle('CERT_REFEREE')}">{$personView->getCertBadge('CERT_REFEREE')}</td>
   </tr><tr>
     <td>Concussion Aware</td>
-    <td class="{$personView->getCertClass('CERT_CONCUSSION')}">{$personView->getCertBadge('CERT_CONCUSSION')}</td>
+    <td style="{$personView->getCertStyle('CERT_CONCUSSION')}">{$personView->getCertBadge('CERT_CONCUSSION')}</td>
   </tr>
   <tr><td>User Notes</td><td>{$notes}</td></tr>
   <tr><td colspan="2"><a href="{$href}">Update Tournament Plans or Availability</a></td></tr>
 </table>
 <br>
-<p>
-  If you plan to referee (or volunteer) then please ensure your eAYSO information is up to date.
-  Anything above that is marked with <span class="bg-danger">***</span> needs action.
-  Please notify the referee administrator if your eAYSO information does not match the above information.
-  The administrator will update zAYSO accordingly.
+<p style="{$this->styleP}">
+    If you plan to referee (or volunteer) then please ensure your eAYSO information is up to date.
+    Anything above that is marked with <span style="{$personView->dangerStyle}">***</span> needs action.
+</p>
+<p style="{$this->styleP}">
+    AYSO requires all participating referees and coaches to have completed AYSO Safe Haven training.
+    If you have yet to complete training, the AYSO Safe Haven Training Course is available online. First, sign into <a href="https://www.aysotraining.org" target="_blank">https://www.aysotraining.org</a>
+    with your eAYSO ID and last name. Then you can access the AYSO Safe Haven Training Course at <a href="https://www.aysotraining.org/training/safehaven/aysosafehaven.asp?course=safehaven" target="_blank">https://www.aysotraining.org/training/safehaven/aysosafehaven.asp?course=safehaven</a>.
+</p>
+<p style="{$this->styleP}">
+    By Florida law, all participating referees and coaches are required to have completed CDC Concussion training.
+    If you have yet to complete training, the AYSO CDC Concussion Training Course is available online. First, sign into <a href="https://www.aysotraining.org" target="_blank">https://www.aysotraining.org</a>
+    with your eAYSO ID and last name. Then you can access the AYSO CDD Concussion Training Course at <a href="https://www.aysotraining.org/training/CDC/cdcfiles/cdc.asp" target="_blank">https://www.aysotraining.org/training/CDC/cdcfiles/cdc.asp</a>.
+</p>
+<p style="{$this->styleP}">
+    These training modules takes about 30 minutes each.  If your record is Please take a time today and complete this training.
+    When it's done, your records will be updated and you'll be ready to join us at the National Games.
+</p>
+<p style="{$this->styleP}">
+    Please notify the referee administrator if your eAYSO information does not match the above information.
+    I will update zAYSO accordingly.
 </p>
 EOD;
     }

--- a/src/AppBundle/Action/Project/Person/Register/RegisterTemplateEmail.php
+++ b/src/AppBundle/Action/Project/Person/Register/RegisterTemplateEmail.php
@@ -159,7 +159,7 @@ EOD;
     with your eAYSO ID and last name. Then you can access the AYSO CDD Concussion Training Course at <a href="https://www.aysotraining.org/training/CDC/cdcfiles/cdc.asp" target="_blank">https://www.aysotraining.org/training/CDC/cdcfiles/cdc.asp</a>.
 </p>
 <p style="{$this->styleP}">
-    These training modules takes about 30 minutes each.  If your record is Please take a time today and complete this training.
+    These training modules takes about 30 minutes each.  If your certification records need action, please take time today and complete this training.
     When it's done, your records will be updated and you'll be ready to join us at the National Games.
 </p>
 <p style="{$this->styleP}">

--- a/src/AppBundle/Action/Project/Person/Register/RegisterTemplateEmail.php
+++ b/src/AppBundle/Action/Project/Person/Register/RegisterTemplateEmail.php
@@ -31,7 +31,7 @@ class RegisterTemplateEmail extends AbstractView2
     ';
     protected $styleBodyEmail = 'width: inherit;';
     protected $stylePEmail = '
-        font-size: 12px;
+        font-size: 14px;
         text-align: center;
     ';
     protected $styleP = '
@@ -39,6 +39,11 @@ class RegisterTemplateEmail extends AbstractView2
     ';
     protected $styleClearBoth = '
         clear: both
+    ';
+    protected $stylePStrong = '
+        text-decoration: underline;
+        font-size: 14px;
+        font-weight: bold;
     ';
 
     public function __construct(
@@ -76,6 +81,9 @@ class RegisterTemplateEmail extends AbstractView2
   <br>
   {$this->renderHtmlPerson($personView)}
 
+  <p style="{$this->stylePStrong}">
+    General Information
+  </p>
   <p style="{$this->styleP}">
     As you might expect, we have a full calendar of soccer and related activities starting Tuesday, July 5 and 
     running through Sunday, July 10. 
@@ -144,6 +152,9 @@ EOD;
   <tr><td colspan="2"><a href="{$href}">Update Tournament Plans or Availability</a></td></tr>
 </table>
 <br>
+  <p style="{$this->stylePStrong}">
+    Please Review Your Certifications
+  </p>
 <p style="{$this->styleP}">
     If you plan to referee (or volunteer) then please ensure your eAYSO information is up to date.
     Anything above that is marked with <span style="{$personView->dangerStyle}">***</span> needs action.
@@ -154,12 +165,12 @@ EOD;
     with your eAYSO ID and last name. Then you can access the AYSO Safe Haven Training Course at <a href="https://www.aysotraining.org/training/safehaven/aysosafehaven.asp?course=safehaven" target="_blank">https://www.aysotraining.org/training/safehaven/aysosafehaven.asp?course=safehaven</a>.
 </p>
 <p style="{$this->styleP}">
-    By Florida law, all participating referees and coaches are required to have completed CDC Concussion training.
+    By Florida law, all participating referees and coaches are required to have completed CDC Concussion Awareness training.
     If you have yet to complete training, the AYSO CDC Concussion Training Course is available online. First, sign into <a href="https://www.aysotraining.org" target="_blank">https://www.aysotraining.org</a>
-    with your eAYSO ID and last name. Then you can access the AYSO CDD Concussion Training Course at <a href="https://www.aysotraining.org/training/CDC/cdcfiles/cdc.asp" target="_blank">https://www.aysotraining.org/training/CDC/cdcfiles/cdc.asp</a>.
+    with your eAYSO ID and last name. Then you can access the AYSO CDC Concussion Awareness Training Course at <a href="https://www.aysotraining.org/training/CDC/cdcfiles/cdc.asp" target="_blank">https://www.aysotraining.org/training/CDC/cdcfiles/cdc.asp</a>.
 </p>
 <p style="{$this->styleP}">
-    These training modules takes about 30 minutes each.  If your certification records need action, please take time today and complete this training.
+    These training modules take about 30 minutes each.  If your certification records need action, please take time today and complete this training.
     When it's done, your records will be updated and you'll be ready to join us at the National Games.
 </p>
 <p style="{$this->styleP}">


### PR DESCRIPTION
Gmail strips out <style>, <head> and <body> tags but other mail clients use them.  So gmail has no access to zayso.css styling.  Converted all classes to inline style statements (yuk!) and views in clients and the browser now look the same.

Reference: https://litmus.com/blog/understanding-gmail-and-css-part-1  and  https://www.emailonacid.com/blog/article/email-development/12_things_you_must_know_when_developing_for_gmail_and_gmail_mobile_apps#gmail_tip2