### PR TITLE
Catch all exceptions(including 404s) and redirect to home.

### DIFF
--- a/app/config/routing.yml
+++ b/app/config/routing.yml
@@ -15,17 +15,9 @@ app_game_official:
     resource: "@AppBundle/Action/GameOfficial/config/routes.yml"
     prefix: /game/official
 
-#app_schedule:
-#    resource: "@AppBundle/Action/Schedule/routes.yml"
-#    prefix: /schedule
-
-schedule_2016:
+app_schedule_2016:
     resource: "@AppBundle/Action/Schedule2016/routes.yml"
     prefix: /schedule
-
-#app_results:
-#    resource: "@AppBundle/Action/Results/routes.yml"
-#    prefix: /results
 
 app_results_2016:
     resource: "@AppBundle/Action/Results2016/routes.yml"
@@ -44,6 +36,6 @@ app_project_person_admin:
     prefix: /project/person/admin
 
 #   must load last
-app__routes__mystery:
+app__app:
     resource: "@AppBundle/Action/App/routes.yml"
     prefix:   /

--- a/src/AppBundle/Action/App/routes.yml
+++ b/src/AppBundle/Action/App/routes.yml
@@ -27,10 +27,10 @@ app_admin:
 #   unknown path trap
 #   must be loaded last
 
-app__mystery__url:
-    path: /{url}/
-    defaults:
-        _controller: FrameworkBundle:Redirect:urlRedirect
-        path: /welcome
-        requirements:
-            url: [.*]
+#app__mystery__url:
+#    path: /{url}/
+#    defaults:
+#        _controller: FrameworkBundle:Redirect:urlRedirect
+#        path: /welcome
+#        requirements:
+#            url: [.*]


### PR DESCRIPTION
Only for production.  Development will continue to show stack trace.
