### PR TITLE
#102 quotes

### DIFF
--- a/src/AppBundle/Action/AbstractForm.php
+++ b/src/AppBundle/Action/AbstractForm.php
@@ -157,7 +157,7 @@ EOD;
     protected function filterScalarString($data,$name)
     {
         $itemData = isset($data[$name]) ? $data[$name] : null;
-        $itemData = filter_var(trim($itemData), FILTER_SANITIZE_STRING );
+        $itemData = filter_var(trim($itemData), FILTER_SANITIZE_STRING, FILTER_FLAG_NO_ENCODE_QUOTES );
         if ($itemData === null || strlen($itemData) < 1) {
             return null;
         }

--- a/src/AppBundle/Action/Project/Person/Register/RegisterForm.php
+++ b/src/AppBundle/Action/Project/Person/Register/RegisterForm.php
@@ -48,7 +48,6 @@ class RegisterForm extends AbstractForm
             $data[$key] = $value;
         }
         // Validate
-        dump($data['notesUser']);
         // $errors = [];
 
         //dump($data);

--- a/src/AppBundle/Action/Project/Person/Register/RegisterForm.php
+++ b/src/AppBundle/Action/Project/Person/Register/RegisterForm.php
@@ -36,7 +36,7 @@ class RegisterForm extends AbstractForm
         foreach($data as $key => $value)
         {
             if (!is_array($value)) {
-                $value = filter_var(trim($value), FILTER_SANITIZE_STRING);
+                $value = filter_var(trim($value), FILTER_SANITIZE_STRING, FILTER_FLAG_NO_ENCODE_QUOTES);
             }
             if (isset($this->formControls[$key])) {
                 $meta = $this->formControls[$key];
@@ -48,6 +48,7 @@ class RegisterForm extends AbstractForm
             $data[$key] = $value;
         }
         // Validate
+        dump($data['notesUser']);
         // $errors = [];
 
         //dump($data);


### PR DESCRIPTION
Had to add FILTER_FLAG_NO_ENCODE_QUOTES to filter_var.  Seems a bit strange but oh well.

Still have notes in the database with quotes encoded as html characters.  Not going to bother to write a fix up script at this point.  The administrator can edit the notes if they so desire.