### PR TITLE
Removed VIP option from program controls.

### DIFF
--- a/app/config/projects.yml
+++ b/app/config/projects.yml
@@ -10,7 +10,7 @@ parameters:
         AYSONationalGames2016:
             programs:
                 Core: Core
-                VIP:  VIP
+            #   VIP:  VIP
             genders:
                 B:  B
                 G:  G


### PR DESCRIPTION
The control will still show up but will only have Core as an option.  Would like to avoid removing the control itself at this point.