### PR TITLE
Fix for removal request

### DIFF
--- a/src/AppBundle/Action/GameOfficial/GameOfficialUpdater.php
+++ b/src/AppBundle/Action/GameOfficial/GameOfficialUpdater.php
@@ -25,9 +25,11 @@ class GameOfficialUpdater
         if ($gameOfficial->assignState !== $gameOfficialOriginal->assignState) {
             $this->gameConn->update('gameOfficials',['assignState' => $gameOfficial->assignState],$id);
         }
+        //dump($gameOfficial);
+        //dump($gameOfficialOriginal);
         // The person
         if ($gameOfficial->regPersonId === $gameOfficialOriginal->regPersonId) {
-            return;
+            //return; // Something is not clearing right, state is being updated to Open
         }
         $gameOfficialUpdateInfo = [
             'phyPersonId'   => null,
@@ -50,6 +52,7 @@ class GameOfficialUpdater
                 'regPersonName' => $row['name'],
             ];
         }
+        //dump($gameOfficialUpdateInfo);
         $this->gameConn->update('gameOfficials',$gameOfficialUpdateInfo,$id);
     }
 }


### PR DESCRIPTION
When requesting to be removed, the state was being updated to Open butt in some as of yet unknown workflow the reg person id was not being changed.

Still not sure how that happened.  Reported via email from Rosemary/Stuart.

This fix ensures that state and regPerson will always update together.  

Need to keep an eye on it.