### PR TITLE
Fix cross pool exception in results.

### DIFF
--- a/src/AppBundle/Action/Results2016/PoolPlay/ResultsPoolPlayController.php
+++ b/src/AppBundle/Action/Results2016/PoolPlay/ResultsPoolPlayController.php
@@ -79,11 +79,16 @@ class ResultsPoolPlayController extends AbstractController2
             $pools = $this->resultsFinder->findPools($criteria);
         }
         if (isset($searchData['poolKey'])) {
-            $criteria['poolKeys'] = [$searchData['poolKey']];
+            //$criteria['poolKeys'] = [$searchData['poolKey']];
+            $poolKey = $searchData['poolKey'];
+            $criteria['divisions'] = [substr($poolKey,0,4)];
             $pools = $this->resultsFinder->findPools($criteria);
+            $pools = array_filter($pools,function($key) use ($poolKey) {
+                return $key === $poolKey;
+            },ARRAY_FILTER_USE_KEY);
         }
         // Get the pools if needed
-        // dump($pools);
+        //dump($pools);
         $request->attributes->set('pools',$pools);
         return null;
     }


### PR DESCRIPTION
Selecting a single pool was causing an exception when cross pool play was involved.  Fix was to always generate results for the complete division and then filter for specific pool.

The of course assumes there is no cross division play.