### PR TITLE
Redirect back to schedule after requesting assignment.

### DIFF
--- a/src/AppBundle/Action/GameOfficial/AssignByAssignee/AssigneeController.php
+++ b/src/AppBundle/Action/GameOfficial/AssignByAssignee/AssigneeController.php
@@ -9,6 +9,7 @@ use AppBundle\Action\GameReport2016\GameReport;
 use AppBundle\Action\GameReport2016\GameReportRepository;
 use AppBundle\Action\GameReport2016\GameReportPointsCalculator;
 
+use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 
 class AssigneeController extends AbstractController2
@@ -73,8 +74,13 @@ class AssigneeController extends AbstractController2
             }
             
             $this->gameOfficialUpdater->updateGameOfficial($gameOfficial,$gameOfficialOriginal);
+
+            $backUrl = $this->generateUrl($backRouteName);
+            $backUrl .= '#game-' . $game->gameId;
+
+            return new RedirectResponse($backUrl);
             
-            return $redirect;
+            //return $redirect;
         }
         $request->attributes->set('game',$game);
         return null;


### PR DESCRIPTION
Before the signup form would redirect back to the form.  The prompts changed slightly but it wasn't really clear to the casual user that the assignment request worked.

With ths patch the user is redirect back to the schedule where they can see their name assigned to the game.  Think it is more clear.