### PR TITLE
270-fix_separator_in_export

### DIFF
--- a/src/AppBundle/Action/Schedule2016/Game/ScheduleGameViewFile.php
+++ b/src/AppBundle/Action/Schedule2016/Game/ScheduleGameViewFile.php
@@ -49,13 +49,19 @@ class ScheduleGameViewFile extends AbstractView2
         foreach ( $games as $game ) {
             $teamHome = $game->homeTeam;
             $teamAway = $game->awayTeam;
+            
+            $poolView = $game->poolView;
+            $sep = '<hr class="separator">';
+            if (strpos($poolView, $sep) !== false) {
+                $poolView = str_replace($sep, ' / ', $poolView);
+            }
 
             $data[] = array(
                 $game->gameNumber,
                 $game->dow,
                 $game->time,
                 $game->fieldName,
-                $game->poolView,
+                $poolView,
                 $teamHome->poolTeamKey,
                 $teamHome->regTeamName,
                 $teamAway->regTeamName,


### PR DESCRIPTION
- replace '<hr class="separator">' in export for cross-pool poolView