### PR TITLE
Added web server bundle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ web/pdf
 src/AppBundle/Resources/pdf/archive
 *alias*
 dist.sh
+/.web-server-pid

--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -27,6 +27,7 @@ class AppKernel extends Kernel
             $bundles[] = new Symfony\Bundle\WebProfilerBundle\WebProfilerBundle();
             $bundles[] = new Sensio\Bundle\DistributionBundle\SensioDistributionBundle();
             $bundles[] = new Sensio\Bundle\GeneratorBundle\SensioGeneratorBundle();
+            $bundles[] = new Symfony\Bundle\WebServerBundle\WebServerBundle();
         }
 
         return $bundles;

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,8 @@
     "require-dev": {
         "sensio/generator-bundle": "^3.0",
         "symfony/phpunit-bridge": "^3.0",
-        "phpunit/phpunit": "^4.8"
+        "phpunit/phpunit": "^4.8",
+        "symfony/web-server-bundle": "^3.4"
     },
     "scripts": {
         "post-install-cmd": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "17118573d153ea147765bcc6202ea47d",
+    "content-hash": "517a378726afe9a204f535f4c6cb3efe",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -3708,7 +3708,6 @@
                 "mock",
                 "xunit"
             ],
-            "abandoned": true,
             "time": "2015-10-02T06:51:40+00:00"
         },
         {

--- a/web/app_dev.php
+++ b/web/app_dev.php
@@ -12,7 +12,7 @@ use Symfony\Component\Debug\Debug;
 // Feel free to remove this, extend it, or make something more sophisticated.
 if ( (isset($_SERVER['HTTP_CLIENT_IP'])
     || isset($_SERVER['HTTP_X_FORWARDED_FOR'])
-    || !(in_array(@$_SERVER['REMOTE_ADDR'], ['127.0.0.1', 'fe80::1', '::1'])) || php_sapi_name() === 'cli-server')
+    || !(in_array(@$_SERVER['REMOTE_ADDR'], ['127.0.0.1', 'fe80::1', '::1'])) || php_sapi_name() === 'cli-serverx')
     //VirtualHost X Local Domain for mobile testing
     && (!strpos($_SERVER['SERVER_NAME'],'.vhx.cloud') )
     && (!strpos($_SERVER['SERVER_NAME'],'.xip.io') )
@@ -29,7 +29,7 @@ $loader = require __DIR__.'/../app/autoload.php';
 Debug::enable();
 
 $kernel = new AppKernel('dev', true);
-$kernel->loadClassCache();
+//$kernel->loadClassCache();
 $request = Request::createFromGlobals();
 $response = $kernel->handle($request);
 $response->send();


### PR DESCRIPTION
I added the [web server bundle](https://symfony.com/doc/3.4/setup/built_in_web_server.html) to the composer.json.  Had to tweak AppKernel to load it.  This should be a safe merge.  You will have to do a composer install to get the bundle.

    bin/console server:start

Will startup a php server for debugging purposes.  Kind of handy.  For development.